### PR TITLE
Pull status from new App.net account to get status from Twitter.

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,13 +12,25 @@
     <link href='http://fonts.googleapis.com/css?family=Raleway:400,500,600' rel='stylesheet' type='text/css'>
     <link href='http://fonts.googleapis.com/css?family=Open+Sans:400,600,700,800' rel='stylesheet' type='text/css'>
     <script src="js/modernizr.js"></script>
+    <script src="js/jquery.js"></script>
+    <script>
+      $(function(){
+        $.getJSON('https://alpha-api.app.net/stream/0/users/@levelupcon/posts', function(res) {
+          var posts = res.data;
+          
+          if(posts.length > 0){
+            status = $('.feed .status').html(posts[0].text);
+          }
+        });
+      });
+    </script>
   </head>
   <body>
     
     <div class="full-width feed">
       <div class="row">
         <div class="large-12 columns header">
-          <h6>Twitter tweets go here.</h6>
+          <h6 class="status">Follow <a href="http://twitter.com/levelupcon">@levelupcon</a> on Twitter.</h6>
         </div>
       </div>
     </div>

--- a/index.html
+++ b/index.html
@@ -12,18 +12,6 @@
     <link href='http://fonts.googleapis.com/css?family=Raleway:400,500,600' rel='stylesheet' type='text/css'>
     <link href='http://fonts.googleapis.com/css?family=Open+Sans:400,600,700,800' rel='stylesheet' type='text/css'>
     <script src="js/modernizr.js"></script>
-    <script src="js/jquery.js"></script>
-    <script>
-      $(function(){
-        $.getJSON('https://alpha-api.app.net/stream/0/users/@levelupcon/posts', function(res) {
-          var posts = res.data;
-          
-          if(posts.length > 0){
-            status = $('.feed .status').html(posts[0].text);
-          }
-        });
-      });
-    </script>
   </head>
   <body>
     
@@ -107,6 +95,16 @@
     <script src="js/foundation.min.js"></script>
     <script>
       $(document).foundation();
+
+      $(function(){
+        $.getJSON('https://alpha-api.app.net/stream/0/users/@levelupcon/posts', function(res) {
+          var posts = res.data;
+          
+          if(posts.length > 0){
+            $('.feed .status').html(posts[0].text);
+          }
+        });
+      });
     </script>
   </body>
 </html>


### PR DESCRIPTION
I set up an App.net and IFTTT account for LevelUpCon and made a recipe. This gets arounds Twitter's shitty API limits. So every new tweet will post the same status to app.net/levelupcon and the site pulls from that.

By default 'Follow @levelupcon on Twitter' will display in the header in case JS or any error happens. At least there will be text there.
